### PR TITLE
init FH profile

### DIFF
--- a/conf/fred_hutch.config
+++ b/conf/fred_hutch.config
@@ -30,27 +30,30 @@ process {
         cpus: 36,
         time: 720.h
     ]
+    // Per the scicomp wiki, memory requests don't mean much on our system. Use CPUs as a proxy for mem requests
+    // Request 1 CPU for each 4 GB of memory
+    // https://sciwiki.fredhutch.org/scicomputing/compute_jobs/#memory
     cpus    = { 1 * task.attempt }
     memory  = { 20.GB * task.attempt }
     time    = { 12.h * task.attempt }
     withLabel:process_single {
-        cpus   = { 1 * task.attempt }
-        memory = { 20.GB * task.attempt }
-        time   = { 20.h * task.attempt }
+        cpus   = { 2 * task.attempt }
+        memory = { 8.GB * task.attempt }
+        time   = { 12.h * task.attempt }
     }
     withLabel:process_low {
-        cpus   = { 2 * task.attempt }
-        memory = { 20.GB * task.attempt }
-        time   = { 5.h  * task.attempt }
+        cpus   = { 4 * task.attempt }
+        memory = { 16.GB * task.attempt }
+        time   = { 24.h  * task.attempt }
     }
     withLabel:process_medium {
         cpus   = { 16 * task.attempt }
-        memory = { 96.GB * task.attempt }
-        time   = { 24.h  * task.attempt }
+        memory = { 56.GB * task.attempt }
+        time   = { 72.h  * task.attempt }
     }
     withLabel:process_high {
         cpus   = 32
-        memory = { 240.GB * task.attempt }
+        memory = { 128.GB * task.attempt }
         time   = { 120.h  * task.attempt }
     }
     withLabel:process_long {

--- a/conf/fred_hutch.config
+++ b/conf/fred_hutch.config
@@ -37,7 +37,8 @@ executor {
 apptainer {
     enabled = true
     cacheDir = params.scratch ? "${params.scratch}" : "${System.getenv('HOME')}/.apptainer/cache/library"
-    runOptions = "--containall -B ${System.getenv('TMPDIR')}"
+    // runOptions = "--containall -B ${System.getenv('TMPDIR')}"
+    runOptions = "--containall -B \$TMPDIR"
 }
 
 workDir = params.scratch ? "${params.scratch}" : "${System.getenv('HOME')}/nextflow"

--- a/conf/fred_hutch.config
+++ b/conf/fred_hutch.config
@@ -7,13 +7,14 @@ params {
     max_memory = 700.GB
     max_cpus = 36
     max_time = 720.h
+    // Assumes user will provide a scratch dir at runtime
     scratch = null
 }
 
 
 process {
     executor = 'slurm'
-    // clusterOptions = {}
+    // clusterOptions = {} // If we want default slurm configs
     queue = { task.time >= 12.h ? 'campus-new' : 'short' }
     maxRetries = 2
     resourceLimits = [
@@ -21,10 +22,10 @@ process {
         cpus: 36,
         time: 720.h
     ]
+    // Maybe not desirable to rely on the module, but this enforces Apptainer to be loaded since we're defaulting apptainer to be enabled
     beforeScript = """
     module load Apptainer
     """
-    // env.NXF_APPTAINER_CACHEDIR = "$HOME/.apptainer/cache"
 }
 
 executor {
@@ -36,11 +37,13 @@ executor {
 
 apptainer {
     enabled = true
+    // If the user does not provide a scratch directory, use their home dir
     cacheDir = params.scratch ? "${params.scratch}" : "${System.getenv('HOME')}/.apptainer/cache/library"
-    // runOptions = "--containall -B ${System.getenv('TMPDIR')}"
+    // Checks if TMPDIR is defined in the environment before mounting to avoid breaks
     runOptions = "--containall" + System.getenv('TMPDIR') ?: "-B \$TMPDIR"
 }
 
+// If the user does not provide a scratch directory, use their home dir
 workDir = params.scratch ? "${params.scratch}" : "${System.getenv('HOME')}/nextflow"
 
 // clean the generated files in the working directory

--- a/conf/fred_hutch.config
+++ b/conf/fred_hutch.config
@@ -33,9 +33,9 @@ process {
     // Per the scicomp wiki, memory requests don't mean much on our system. Use CPUs as a proxy for mem requests
     // Request 1 CPU for each 4 GB of memory
     // https://sciwiki.fredhutch.org/scicomputing/compute_jobs/#memory
-    cpus    = { 10 * task.attempt }
-    memory  = { 40.GB * task.attempt }
-    time    = { 48.h * task.attempt }
+    cpus    = { 5 * task.attempt }
+    memory  = { 20.GB * task.attempt }
+    time    = { 24.h * task.attempt }
     withLabel:process_single {
         cpus   = { 2 * task.attempt }
         memory = { 8.GB * task.attempt }
@@ -73,7 +73,7 @@ executor {
 apptainer {
     enabled = true
     // If the user does not provide a scratch directory, use their home dir
-    cacheDir = params.scratch ? "${params.scratch}" : "${System.getenv('HOME')}/.apptainer/cache/library"
+    cacheDir = params.scratch ? "${params.scratch}/.apptainer/cache" : "${System.getenv('HOME')}/.apptainer/cache"
     // Checks if TMPDIR is defined in the environment before mounting to avoid breaks
     runOptions = "--containall " + (System.getenv('TMPDIR') ? "-B \$TMPDIR" : "")
 }

--- a/conf/fred_hutch.config
+++ b/conf/fred_hutch.config
@@ -35,7 +35,7 @@ process {
     // https://sciwiki.fredhutch.org/scicomputing/compute_jobs/#memory
     cpus    = { 10 * task.attempt }
     memory  = { 40.GB * task.attempt }
-    time    = { 12.h * task.attempt }
+    time    = { 48.h * task.attempt }
     withLabel:process_single {
         cpus   = { 2 * task.attempt }
         memory = { 8.GB * task.attempt }

--- a/conf/fred_hutch.config
+++ b/conf/fred_hutch.config
@@ -75,7 +75,7 @@ apptainer {
     // If the user does not provide a scratch directory, use their home dir
     cacheDir = params.scratch ? "${params.scratch}" : "${System.getenv('HOME')}/.apptainer/cache/library"
     // Checks if TMPDIR is defined in the environment before mounting to avoid breaks
-    runOptions = "--containall" + System.getenv('TMPDIR') ?: "-B \$TMPDIR"
+    runOptions = "--containall" + System.getenv('TMPDIR') ? "-B \$TMPDIR" : "" 
 }
 
 // clean the generated files in the working directory

--- a/conf/fred_hutch.config
+++ b/conf/fred_hutch.config
@@ -37,11 +37,11 @@ executor {
 apptainer {
     enabled = true
     // Might be nice to have a public cache to avoid redundant downloads
-    cacheDir = ${params.scratch ?: "${HOME}/.apptainer/cache/library"}
+    cacheDir = ${params.scratch ?: "\$HOME/.apptainer/cache/library"}
     runOptions = '--containall -B \$TMPDIR'
 }
 
-workDir = ${params.scratch ?: "${HOME}/nextflow"}
+workDir = ${params.scratch ?: "\$HOME/nextflow"}
 
 // clean the generated files in the working directory
 // having this as true sometimes breaks things

--- a/conf/fred_hutch.config
+++ b/conf/fred_hutch.config
@@ -36,12 +36,11 @@ executor {
 
 apptainer {
     enabled = true
-    // Might be nice to have a public cache to avoid redundant downloads
-    cacheDir = ${params.scratch ?: "\$HOME/.apptainer/cache/library"}
-    runOptions = '--containall -B \$TMPDIR'
+    cacheDir = params.scratch ? "${params.scratch}" : "${System.getenv('HOME')}/.apptainer/cache/library"
+    runOptions = "--containall -B ${System.getenv('TMPDIR')}"
 }
 
-workDir = ${params.scratch ?: "\$HOME/nextflow"}
+workDir = params.scratch ? "${params.scratch}" : "${System.getenv('HOME')}/nextflow"
 
 // clean the generated files in the working directory
 // having this as true sometimes breaks things

--- a/conf/fred_hutch.config
+++ b/conf/fred_hutch.config
@@ -75,7 +75,7 @@ apptainer {
     // If the user does not provide a scratch directory, use their home dir
     cacheDir = params.scratch ? "${params.scratch}" : "${System.getenv('HOME')}/.apptainer/cache/library"
     // Checks if TMPDIR is defined in the environment before mounting to avoid breaks
-    runOptions = "--containall" + System.getenv('TMPDIR') ? "-B \$TMPDIR" : "" 
+    runOptions = "--containall " + (System.getenv('TMPDIR') ? "-B \$TMPDIR" : "")
 }
 
 // clean the generated files in the working directory

--- a/conf/fred_hutch.config
+++ b/conf/fred_hutch.config
@@ -33,8 +33,8 @@ process {
     // Per the scicomp wiki, memory requests don't mean much on our system. Use CPUs as a proxy for mem requests
     // Request 1 CPU for each 4 GB of memory
     // https://sciwiki.fredhutch.org/scicomputing/compute_jobs/#memory
-    cpus    = { 1 * task.attempt }
-    memory  = { 20.GB * task.attempt }
+    cpus    = { 10 * task.attempt }
+    memory  = { 40.GB * task.attempt }
     time    = { 12.h * task.attempt }
     withLabel:process_single {
         cpus   = { 2 * task.attempt }

--- a/conf/fred_hutch.config
+++ b/conf/fred_hutch.config
@@ -38,7 +38,7 @@ apptainer {
     enabled = true
     cacheDir = params.scratch ? "${params.scratch}" : "${System.getenv('HOME')}/.apptainer/cache/library"
     // runOptions = "--containall -B ${System.getenv('TMPDIR')}"
-    runOptions = "--containall -B \$TMPDIR"
+    runOptions = "--containall" + System.getenv('TMPDIR') ?: "-B \$TMPDIR"
 }
 
 workDir = params.scratch ? "${params.scratch}" : "${System.getenv('HOME')}/nextflow"

--- a/conf/fred_hutch.config
+++ b/conf/fred_hutch.config
@@ -14,7 +14,7 @@ params {
 process {
     executor = 'slurm'
     // clusterOptions = {}
-    queue = { task.time <= 12.h ? 'short' : 'campus-new' }
+    queue = { task.time >= 12.h ? 'campus-new' : 'short' }
     maxRetries = 2
     resourceLimits = [
         memory: 700.GB,

--- a/conf/fred_hutch.config
+++ b/conf/fred_hutch.config
@@ -3,6 +3,11 @@ params {
     config_profile_description = 'Fred Hutch Cancer Center HPC profile'
     config_profile_contact     = ''
     config_profile_url         = 'https://sciwiki.fredhutch.org/'
+    // Same as resourceLimits, but for older pipelines
+    max_memory = 700.GB
+    max_cpus = 36
+    max_time = 720.h
+    scratch = null
 }
 
 
@@ -16,10 +21,6 @@ process {
         cpus: 36,
         time: 720.h
     ]
-    // Same as resourceLimits, but for older pipelines
-    max_memory = 700.GB
-    max_cpus = 36
-    max_time = 720.h
     beforeScript = """
     module load Apptainer
     """
@@ -36,8 +37,12 @@ executor {
 apptainer {
     enabled = true
     // Might be nice to have a public cache to avoid redundant downloads
-    cacheDir = "${HOME}/.apptainer/cache/library"
+    cacheDir = ${params.scratch ?: "${HOME}/.apptainer/cache/library"}
+    runOptions = '--containall -B \$TMPDIR'
 }
 
+workDir = ${params.scratch ?: "${HOME}/nextflow"}
+
 // clean the generated files in the working directory
-cleanup = true
+// having this as true sometimes breaks things
+cleanup = false

--- a/conf/fred_hutch.config
+++ b/conf/fred_hutch.config
@@ -11,21 +11,53 @@ params {
     scratch = null
 }
 
+// If the user does not provide a scratch directory, use their home dir
+workDir = params.scratch ? "${params.scratch}" : "${System.getenv('HOME')}/nextflow"
 
 process {
     executor = 'slurm'
     // clusterOptions = {} // If we want default slurm configs
-    queue = { task.time >= 12.h ? 'campus-new' : 'short' }
+    queue = { task.time > 12.h ? 'campus-new' : 'short' }
+    
     maxRetries = 2
+    errorStrategy = { task.exitStatus in [12,104,137,134,139,140,143,151,247] ? 'retry' : 'finish' }
+
+    // Maybe not desirable to rely on the module, but this enforces Apptainer to be loaded since we're defaulting apptainer to be enabled
+    beforeScript = "module load Apptainer"
+
     resourceLimits = [
         memory: 700.GB,
         cpus: 36,
         time: 720.h
     ]
-    // Maybe not desirable to rely on the module, but this enforces Apptainer to be loaded since we're defaulting apptainer to be enabled
-    beforeScript = """
-    module load Apptainer
-    """
+    cpus    = { 1 * task.attempt }
+    memory  = { 20.GB * task.attempt }
+    time    = { 12.h * task.attempt }
+    withLabel:process_single {
+        cpus   = { 1 * task.attempt }
+        memory = { 20.GB * task.attempt }
+        time   = { 20.h * task.attempt }
+    }
+    withLabel:process_low {
+        cpus   = { 2 * task.attempt }
+        memory = { 20.GB * task.attempt }
+        time   = { 5.h  * task.attempt }
+    }
+    withLabel:process_medium {
+        cpus   = { 16 * task.attempt }
+        memory = { 96.GB * task.attempt }
+        time   = { 24.h  * task.attempt }
+    }
+    withLabel:process_high {
+        cpus   = 32
+        memory = { 240.GB * task.attempt }
+        time   = { 120.h  * task.attempt }
+    }
+    withLabel:process_long {
+        cpus   = { 12 * task.attempt }
+        memory = { 96.GB * task.attempt }
+        time   = { 336.h  * task.attempt }
+    }
 }
 
 executor {
@@ -42,9 +74,6 @@ apptainer {
     // Checks if TMPDIR is defined in the environment before mounting to avoid breaks
     runOptions = "--containall" + System.getenv('TMPDIR') ?: "-B \$TMPDIR"
 }
-
-// If the user does not provide a scratch directory, use their home dir
-workDir = params.scratch ? "${params.scratch}" : "${System.getenv('HOME')}/nextflow"
 
 // clean the generated files in the working directory
 // having this as true sometimes breaks things

--- a/docs/fred_hutch.md
+++ b/docs/fred_hutch.md
@@ -18,3 +18,5 @@ nextflow run -profile fred_hutch ...
 
 # Additional resources
 
+https://sciwiki.fredhutch.org/datascience/using_workflows/
+https://sciwiki.fredhutch.org/compdemos/nextflow/


### PR DESCRIPTION
I added some resource defaults based on process tags but they may be too generous/stringent. We could remove, but I think it's a decent idea to have defaults, as moderately competent users can overwrite them and the dynamic retry will increase them if they are too strict. 

I didn't review all the error codes closely for the retry conditions, but I saw them in another config so I figure they're decent. 

It can be tested with any nf-core pipeline by specifying the profile and custom config base like so:

```
nextflow run nf-core/demultiplex \
    -profile fred_hutch,test \
    --outdir <scract/testdir> \
    --custom_config_base 'https://raw.githubusercontent.com/Fred-Hutch-Innovation-Lab/configs/master'
```